### PR TITLE
Add basic unit test and CI

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,0 +1,23 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.22.0'
+          channel: stable
+      - run: flutter pub get
+        working-directory: dntu_focus
+      - run: flutter analyze
+        working-directory: dntu_focus
+      - run: flutter test
+        working-directory: dntu_focus

--- a/dntu_focus/lib/features/home/domain/home_cubit.dart
+++ b/dntu_focus/lib/features/home/domain/home_cubit.dart
@@ -36,9 +36,14 @@ class TimerActions {
 }
 
 class HomeCubit extends Cubit<HomeState> {
-  HomeCubit() : super(const HomeState()) {
-    _initialize();
-    _initAudioPlayerListeners(); // NEW: Gọi hàm khởi tạo listener cho AudioPlayer
+  /// When [skipInit] is true the cubit will not perform heavy initialization
+  /// such as opening Hive boxes or setting up audio listeners. This is useful
+  /// for unit tests where those dependencies are not available.
+  HomeCubit({bool skipInit = false}) : super(const HomeState()) {
+    if (!skipInit) {
+      _initialize();
+      _initAudioPlayerListeners(); // NEW: Gọi hàm khởi tạo listener cho AudioPlayer
+    }
   }
 
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;

--- a/dntu_focus/test/home_cubit_test.dart
+++ b/dntu_focus/test/home_cubit_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moji_todo/features/home/domain/home_cubit.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('HomeCubit timer logic', () {
+    test('startTimer sets correct initial state when counting down', () {
+      final cubit = HomeCubit(skipInit: true);
+      expect(cubit.state.isTimerRunning, false);
+      cubit.startTimer();
+      expect(cubit.state.isTimerRunning, true);
+      expect(cubit.state.isPaused, false);
+      expect(cubit.state.timerSeconds, cubit.state.workDuration * 60);
+      expect(cubit.state.currentSession, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add optional skipInit parameter to `HomeCubit` constructor
- create simple unit test for timer logic
- add GitHub Actions workflow for `flutter analyze` and `flutter test`

## Testing
- `flutter test ./dntu_focus/test/home_cubit_test.dart` *(fails: command not found)*
- `flutter analyze dntu_focus` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68471904bd388321867d0fda19f7b26f