### PR TITLE
Fix report model serialization and typo

### DIFF
--- a/dntu_focus/lib/features/report/data/models/pomodoro_session_model.g.dart
+++ b/dntu_focus/lib/features/report/data/models/pomodoro_session_model.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pomodoro_session_model.dart';
+
+PomodoroSessionRecordModel _$PomodoroSessionRecordModelFromJson(Map<String, dynamic> json) {
+  return PomodoroSessionRecordModel(
+    id: json['id'] as String,
+    userId: json['userId'] as String,
+    startTime: const TimestampConverter().fromJson(json['startTime'] as Timestamp),
+    endTime: const TimestampConverter().fromJson(json['endTime'] as Timestamp),
+    duration: json['duration'] as int,
+    isWorkSession: json['isWorkSession'] as bool,
+    taskId: json['taskId'] as String?,
+    projectId: json['projectId'] as String?,
+  );
+}
+
+Map<String, dynamic> _$PomodoroSessionRecordModelToJson(PomodoroSessionRecordModel instance) => <String, dynamic>{
+      'id': instance.id,
+      'userId': instance.userId,
+      'startTime': const TimestampConverter().toJson(instance.startTime),
+      'endTime': const TimestampConverter().toJson(instance.endTime),
+      'duration': instance.duration,
+      'isWorkSession': instance.isWorkSession,
+      'taskId': instance.taskId,
+      'projectId': instance.projectId,
+    };

--- a/dntu_focus/lib/features/report/presentation/tab/tasks_report_tab.dart
+++ b/dntu_focus/lib/features/report/presentation/tab/tasks_report_tab.dart
@@ -20,7 +20,7 @@ class TasksReportTab extends StatelessWidget {
           const SizedBox(height: 16),
           _buildTaskFocusList(),
           const SizedBox(height: 24),
-          _buildSectionHeader(context, title: 'Project Time Disctribution', filter: 'Weekly'),
+          _buildSectionHeader(context, title: 'Project Time Distribution', filter: 'Weekly'),
           const SizedBox(height: 16),
           // Placeholder cho biểu đồ Donut
           Container(


### PR DESCRIPTION
## Summary
- implement missing generated JSON serialization code for `PomodoroSessionRecordModel`
- fix a typo in the tasks report tab label

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847cb8da7d4832189d8a5dd267ed354