### PR TITLE
Fix report feature model types

### DIFF
--- a/dntu_focus/lib/features/report/data/models/pomodoro_session_model.g.dart
+++ b/dntu_focus/lib/features/report/data/models/pomodoro_session_model.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pomodoro_session_model.dart';
+
+PomodoroSessionRecordModel _$PomodoroSessionRecordModelFromJson(Map<String, dynamic> json) {
+  return PomodoroSessionRecordModel(
+    id: json['id'] as String,
+    userId: json['userId'] as String,
+    startTime: const TimestampConverter().fromJson(json['startTime'] as Timestamp),
+    endTime: const TimestampConverter().fromJson(json['endTime'] as Timestamp),
+    duration: json['duration'] as int,
+    isWorkSession: json['isWorkSession'] as bool,
+    taskId: json['taskId'] as String?,
+    projectId: json['projectId'] as String?,
+  );
+}
+
+Map<String, dynamic> _$PomodoroSessionRecordModelToJson(PomodoroSessionRecordModel instance) => <String, dynamic>{
+  'id': instance.id,
+  'userId': instance.userId,
+  'startTime': const TimestampConverter().toJson(instance.startTime),
+  'endTime': const TimestampConverter().toJson(instance.endTime),
+  'duration': instance.duration,
+  'isWorkSession': instance.isWorkSession,
+  'taskId': instance.taskId,
+  'projectId': instance.projectId,
+};

--- a/dntu_focus/lib/features/report/data/report_repository.dart
+++ b/dntu_focus/lib/features/report/data/report_repository.dart
@@ -34,7 +34,7 @@ class ReportRepository {
   }
 
   // Helper để lấy collection `tasks` của user hiện tại
-  CollectionReference<TaskModel> _tasksCollection() {
+  CollectionReference<Task> _tasksCollection() {
     final userId = _userId;
     if (userId == null) {
       throw Exception('User is not logged in.');
@@ -43,8 +43,8 @@ class ReportRepository {
         .collection('users')
         .doc(userId)
         .collection('tasks')
-        .withConverter<TaskModel>(
-      fromFirestore: (snapshot, _) => TaskModel.fromFirestore(snapshot),
+        .withConverter<Task>(
+      fromFirestore: (snapshot, _) => Task.fromFirestore(snapshot),
       toFirestore: (model, _) => model.toJson(),
     );
   }

--- a/dntu_focus/lib/features/report/domain/report_cubit.dart
+++ b/dntu_focus/lib/features/report/domain/report_cubit.dart
@@ -71,8 +71,8 @@ class ReportCubit extends Cubit<ReportState> {
         taskFocusTime: results[9] as Map<String, int>,
         focusTimeChartData: results[10] as Map<DateTime, Map<String?, int>>,
         // Dữ liệu tra cứu
-        allProjects: results[11] as List<ProjectModel>,
-        allTasks: results[12] as List<TaskModel>,
+        allProjects: results[11] as List<Project>,
+        allTasks: results[12] as List<Task>,
       ));
 
     } catch (e) {

--- a/dntu_focus/lib/features/report/domain/report_state.dart
+++ b/dntu_focus/lib/features/report/domain/report_state.dart
@@ -32,8 +32,8 @@ class ReportState extends Equatable {
   final Map<DateTime, Map<String?, int>> focusTimeChartData; // date -> {projectId -> duration}
 
   // Dữ liệu thô để tra cứu tên, màu sắc...
-  final List<ProjectModel> allProjects;
-  final List<TaskModel> allTasks;
+  final List<Project> allProjects;
+  final List<Task> allTasks;
 
   // Các bộ lọc hiện tại
   final ReportDataFilter projectDistributionFilter;
@@ -75,8 +75,8 @@ class ReportState extends Equatable {
     Map<String?, int>? projectTimeDistribution,
     Map<String, int>? taskFocusTime,
     Map<DateTime, Map<String?, int>>? focusTimeChartData,
-    List<ProjectModel>? allProjects,
-    List<TaskModel>? allTasks,
+    List<Project>? allProjects,
+    List<Task>? allTasks,
     ReportDataFilter? projectDistributionFilter,
     ReportDataFilter? focusTimeChartFilter,
   }) {

--- a/dntu_focus/lib/features/report/presentation/tab/tasks_report_tab.dart
+++ b/dntu_focus/lib/features/report/presentation/tab/tasks_report_tab.dart
@@ -173,8 +173,16 @@ class TasksReportTab extends StatelessWidget {
           children: sortedTasks.map((entry) {
             final taskId = entry.key;
             final durationInSeconds = entry.value;
-            final task = state.allTasks.firstWhere((t) => t.id == taskId, orElse: () => TaskModel.empty.copyWith(id: '?', title: 'Unknown Task'));
-            final project = task.projectId != null ? state.allProjects.firstWhere((p) => p.id == task.projectId, orElse: () => ProjectModel.empty) : null;
+            final task = state.allTasks.firstWhere(
+              (t) => t.id == taskId,
+              orElse: () => Task(id: '?', title: 'Unknown Task'),
+            );
+            final project = task.projectId != null
+                ? state.allProjects.firstWhere(
+                    (p) => p.id == task.projectId,
+                    orElse: () => Project(id: '', name: 'Unknown Project', color: Colors.grey),
+                  )
+                : null;
 
             return TaskFocusListItem(
               title: task.title,

--- a/dntu_focus/lib/features/tasks/data/models/task_model.dart
+++ b/dntu_focus/lib/features/tasks/data/models/task_model.dart
@@ -104,6 +104,14 @@ class Task {
     );
   }
 
+  static Task fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    if (data == null) {
+      throw Exception('Document does not exist');
+    }
+    return Task.fromJson(data, docId: doc.id);
+  }
+
   Map<String, dynamic> toJson() {
     return {
       // Không gửi 'id' ở đây nếu bạn dùng ID của document làm ID task trên Firestore


### PR DESCRIPTION
## Summary
- correct references to Project and Task classes
- add JSON serialization file for PomodoroSessionRecordModel
- support creating Task from Firestore snapshots
- update tasks report tab fallback logic

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847e88fc7ec8321abe8dd03c86c19fb