### PR TITLE
Optimize Android notification handling

### DIFF
--- a/dntu_focus/android/app/src/main/AndroidManifest.xml
+++ b/dntu_focus/android/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
 
         <!-- Session End Receiver -->
         <receiver
-            android:name=".MainActivity$sessionEndReceiver"
+            android:name=".SessionEndReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.example.moji_todo.SESSION_END" />

--- a/dntu_focus/android/app/src/main/kotlin/com/example/moji_todo/MainActivity.kt
+++ b/dntu_focus/android/app/src/main/kotlin/com/example/moji_todo/MainActivity.kt
@@ -18,9 +18,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import android.Manifest
 import androidx.core.app.ActivityCompat
-import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.IntentFilter
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.media.AudioAttributes
@@ -37,27 +35,9 @@ class MainActivity : FlutterActivity() {
     private val REQUEST_NOTIFICATION_PERMISSION = 1001
     private val REQUEST_IGNORE_BATTERY_OPTIMIZATIONS = 1002
 
-    class sessionEndReceiver : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            Log.d("MainActivity", "Received broadcast in static receiver: action=${intent.action}")
-            if (intent.action == TimerService.ACTION_SESSION_END) {
-                val isWorkSession = intent.getBooleanExtra("isWorkSession", true)
-                Log.d("MainActivity", "Processing SESSION_END in static receiver: isWorkSession=$isWorkSession")
-
-                val mainActivityIntent = Intent(context, MainActivity::class.java).apply {
-                    action = "com.example.moji_todo.SESSION_END_ACTIVATED"
-                    putExtra("isWorkSession", isWorkSession)
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                }
-                context.startActivity(mainActivityIntent)
-                Log.d("MainActivity", "Sent intent to MainActivity to handle SESSION_END from static receiver.")
-            }
-        }
-    }
-
     companion object {
         var timerEvents: EventChannel.EventSink? = null
-        const val TIMER_NOTIFICATION_ID = 100
+        const val TIMER_NOTIFICATION_ID = TimerService.TIMER_NOTIFICATION_ID
         const val SESSION_END_NOTIFICATION_ID = 101
     }
 

--- a/dntu_focus/android/app/src/main/kotlin/com/example/moji_todo/SessionEndReceiver.kt
+++ b/dntu_focus/android/app/src/main/kotlin/com/example/moji_todo/SessionEndReceiver.kt
@@ -1,0 +1,23 @@
+package com.example.moji_todo
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+class SessionEndReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d("SessionEndReceiver", "Received broadcast: action=${intent.action}")
+        if (intent.action == TimerService.ACTION_SESSION_END) {
+            val isWorkSession = intent.getBooleanExtra("isWorkSession", true)
+            Log.d("SessionEndReceiver", "Processing SESSION_END: isWorkSession=$isWorkSession")
+            val mainActivityIntent = Intent(context, MainActivity::class.java).apply {
+                action = "com.example.moji_todo.SESSION_END_ACTIVATED"
+                putExtra("isWorkSession", isWorkSession)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+            context.startActivity(mainActivityIntent)
+            Log.d("SessionEndReceiver", "Launched MainActivity for session end")
+        }
+    }
+}

--- a/dntu_focus/android/app/src/main/kotlin/com/example/moji_todo/TimerService.kt
+++ b/dntu_focus/android/app/src/main/kotlin/com/example/moji_todo/TimerService.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
 import android.app.PendingIntent
 import android.content.ComponentName
 import android.content.Context
+import com.example.moji_todo.SessionEndReceiver
 
 interface TimerStrategy {
     fun tick(currentSeconds: Int): Int
@@ -434,7 +435,7 @@ class TimerService : Service() {
             }
             try {
                 val explicitIntent = Intent(intent).apply {
-                    component = ComponentName(applicationContext, MainActivity.sessionEndReceiver::class.java)
+                    component = ComponentName(applicationContext, SessionEndReceiver::class.java)
                 }
                 sendBroadcast(explicitIntent)
                 hasSentEndNotification = true


### PR DESCRIPTION
## Summary
- move `sessionEndReceiver` into its own `SessionEndReceiver` class
- reference `TimerService.TIMER_NOTIFICATION_ID` from `MainActivity`
- update manifest and service to use the new receiver

## Testing
- `gradlew` unavailable
- `flutter` unavailable

------
https://chatgpt.com/codex/tasks/task_b_6847ea1784f08321921fb5448f32fa80