### PR TITLE
Fix type mismatch in ReportCubit for project/task lists

### DIFF
--- a/dntu_focus/lib/features/report/domain/report_cubit.dart
+++ b/dntu_focus/lib/features/report/domain/report_cubit.dart
@@ -69,8 +69,10 @@ class ReportCubit extends Cubit<ReportState> {
       // Kiểm tra và ép kiểu an toàn cho projects và tasks
       final projectsRaw = results[13];
       final tasksRaw = results[14];
-      final projects = projectsRaw is List ? projectsRaw.cast<Project>() : [];
-      final tasks = tasksRaw is List ? tasksRaw.cast<Task>() : [];
+      final List<Project> projects =
+          projectsRaw is List ? projectsRaw.cast<Project>() : <Project>[];
+      final List<Task> tasks =
+          tasksRaw is List ? tasksRaw.cast<Task>() : <Task>[];
 
       // Gán kết quả vào state
       emit(state.copyWith(


### PR DESCRIPTION
## Summary
- ensure lists of projects and tasks are properly typed in `ReportCubit`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847fe7f62d083218080210c7f0abc03