### PR TITLE
Add Firestore index configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # DNTU-Focus
+
+This Flutter project uses Cloud Firestore for storing tasks and pomodoro sessions. Some queries combine multiple fields and require composite indexes. If these indexes are missing you may see errors such as:
+
+```
+PlatformException(firebase_firestore, FAILED_PRECONDITION: The query requires an index.)
+```
+
+Make sure the Firestore indexes are deployed before running the app:
+
+```bash
+firebase deploy --only firestore:indexes
+```
+
+The required indexes are defined in `dntu_focus/firestore.indexes.json`.

--- a/dntu_focus/firestore.indexes.json
+++ b/dntu_focus/firestore.indexes.json
@@ -1,0 +1,14 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isCompleted", "order": "ASCENDING" },
+        { "fieldPath": "completionDate", "order": "ASCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- document Firestore index requirement in README
- add `firestore.indexes.json` describing the composite index needed for counting completed tasks

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684806c2db888321ae5e648333406578