### PR TITLE
Enable real data in report heatmap

### DIFF
--- a/dntu_focus/lib/features/report/domain/report_cubit.dart
+++ b/dntu_focus/lib/features/report/domain/report_cubit.dart
@@ -44,6 +44,10 @@ class ReportCubit extends Cubit<ReportState> {
         _reportRepository.getTaskFocusTime(ReportTimeRange.lastTwoWeeks), // Future<Map<String, Duration>>
         _reportRepository.getFocusTimeChartData(ReportTimeRange.lastTwoWeeks), // Future<Map<DateTime, Map<String?, Duration>>>
 
+        // Heatmap and goal data
+        _reportRepository.getPomodoroRecordsHeatmapData(range: ReportTimeRange.lastTwoWeeks),
+        _reportRepository.getDaysMeetingFocusGoal(ReportTimeRange.lastTwoWeeks, const Duration(hours: 2)),
+
         // Dữ liệu tra cứu
         Future.value(_projectTagRepository.getProjects()), // Future<List<Project>>
         _taskRepository.getTasks(), // Future<List<Task>>
@@ -65,10 +69,12 @@ class ReportCubit extends Cubit<ReportState> {
       final projectTimeDistribution = results[10] as Map<String?, Duration>;
       final taskFocusTime = results[11] as Map<String, Duration>;
       final focusTimeChartData = results[12] as Map<DateTime, Map<String?, Duration>>;
+      final heatmapData = results[13] as Map<DateTime, List<PomodoroSessionRecordModel>>;
+      final goalDays = results[14] as Set<DateTime>;
 
       // Kiểm tra và ép kiểu an toàn cho projects và tasks
-      final projectsRaw = results[13];
-      final tasksRaw = results[14];
+      final projectsRaw = results[15];
+      final tasksRaw = results[16];
       final List<Project> projects =
           projectsRaw is List ? projectsRaw.cast<Project>() : <Project>[];
       final List<Task> tasks =
@@ -93,6 +99,8 @@ class ReportCubit extends Cubit<ReportState> {
         projectTimeDistribution: projectTimeDistribution,
         taskFocusTime: taskFocusTime,
         focusTimeChartData: focusTimeChartData,
+        pomodoroHeatmapData: heatmapData,
+        focusGoalMetDays: goalDays,
         // Dữ liệu tra cứu
         allProjects: projects.isEmpty ? [] : projects,
         allTasks: tasks.isEmpty ? [] : tasks,

--- a/dntu_focus/lib/features/report/domain/report_state.dart
+++ b/dntu_focus/lib/features/report/domain/report_state.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:moji_todo/features/tasks/data/models/project_model.dart';
 import 'package:moji_todo/features/tasks/data/models/task_model.dart';
+import 'package:moji_todo/features/report/data/models/pomodoro_session_model.dart';
 
 enum ReportStatus { initial, loading, success, failure }
 enum ReportDataFilter { daily, weekly, biweekly, monthly, yearly }
@@ -22,6 +23,8 @@ class ReportState extends Equatable {
   final Map<String?, Duration> projectTimeDistribution;
   final Map<String, Duration> taskFocusTime;
   final Map<DateTime, Map<String?, Duration>> focusTimeChartData;
+  final Map<DateTime, List<PomodoroSessionRecordModel>> pomodoroHeatmapData;
+  final Set<DateTime> focusGoalMetDays;
   final List<Project> allProjects;
   final List<Task> allTasks;
   final ReportDataFilter projectDistributionFilter;
@@ -43,6 +46,8 @@ class ReportState extends Equatable {
     this.projectTimeDistribution = const {},
     this.taskFocusTime = const {},
     this.focusTimeChartData = const {},
+    this.pomodoroHeatmapData = const {},
+    this.focusGoalMetDays = const {},
     this.allProjects = const [],
     this.allTasks = const [],
     this.projectDistributionFilter = ReportDataFilter.weekly,
@@ -65,6 +70,8 @@ class ReportState extends Equatable {
     Map<String?, Duration>? projectTimeDistribution,
     Map<String, Duration>? taskFocusTime,
     Map<DateTime, Map<String?, Duration>>? focusTimeChartData,
+    Map<DateTime, List<PomodoroSessionRecordModel>>? pomodoroHeatmapData,
+    Set<DateTime>? focusGoalMetDays,
     List<Project>? allProjects,
     List<Task>? allTasks,
     ReportDataFilter? projectDistributionFilter,
@@ -86,6 +93,8 @@ class ReportState extends Equatable {
       projectTimeDistribution: projectTimeDistribution ?? this.projectTimeDistribution,
       taskFocusTime: taskFocusTime ?? this.taskFocusTime,
       focusTimeChartData: focusTimeChartData ?? this.focusTimeChartData,
+      pomodoroHeatmapData: pomodoroHeatmapData ?? this.pomodoroHeatmapData,
+      focusGoalMetDays: focusGoalMetDays ?? this.focusGoalMetDays,
       allProjects: allProjects ?? this.allProjects,
       allTasks: allTasks ?? this.allTasks,
       projectDistributionFilter: projectDistributionFilter ?? this.projectDistributionFilter,
@@ -110,6 +119,8 @@ class ReportState extends Equatable {
     projectTimeDistribution,
     taskFocusTime,
     focusTimeChartData,
+    pomodoroHeatmapData,
+    focusGoalMetDays,
     allProjects,
     allTasks,
     projectDistributionFilter,

--- a/dntu_focus/lib/features/report/presentation/tab/pomodoro_report_tab.dart
+++ b/dntu_focus/lib/features/report/presentation/tab/pomodoro_report_tab.dart
@@ -5,6 +5,7 @@ import 'package:moji_todo/features/report/domain/report_state.dart';
 import 'package:table_calendar/table_calendar.dart';
 import '../widgets/focus_time_bar_chart.dart';
 import '../widgets/summary_card.dart';
+import '../widgets/pomodoro_heatmap.dart';
 
 class PomodoroReportTab extends StatelessWidget {
   const PomodoroReportTab({super.key});
@@ -36,7 +37,7 @@ class PomodoroReportTab extends StatelessWidget {
           const SizedBox(height: 24),
           _buildSectionHeader(context, title: 'Pomodoro Records', filterText: 'Weekly'),
           const SizedBox(height: 16),
-          _buildPomodoroHeatmap(),
+          _buildPomodoroHeatmap(context),
           const SizedBox(height: 24),
           _buildSectionHeader(context, title: 'Focus Time Goal', filterText: 'Monthly'),
           const SizedBox(height: 16),
@@ -133,18 +134,17 @@ class PomodoroReportTab extends StatelessWidget {
     );
   }
 
-  Widget _buildPomodoroHeatmap() {
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: Colors.grey.shade200)),
-      child: const Center(
-        child: Text(
-          'Heatmap sẽ được hiển thị ở đây',
-          style: TextStyle(color: Colors.grey),
-        ),
+  Widget _buildPomodoroHeatmap(BuildContext context) {
+    final state = context.watch<ReportCubit>().state;
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: Colors.grey.shade300),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: PomodoroHeatmap(data: state.pomodoroHeatmapData),
       ),
     );
   }
@@ -178,7 +178,10 @@ class PomodoroReportTab extends StatelessWidget {
             ),
             selectedTextStyle: TextStyle(color: Theme.of(context).primaryColor),
           ),
-          selectedDayPredicate: (day) => day.day % 3 == 0,
+          selectedDayPredicate: (day) {
+            final state = context.watch<ReportCubit>().state;
+            return state.focusGoalMetDays.contains(DateUtils.dateOnly(day));
+          },
         ),
       ),
     );

--- a/dntu_focus/lib/features/report/presentation/widgets/pomodoro_heatmap.dart
+++ b/dntu_focus/lib/features/report/presentation/widgets/pomodoro_heatmap.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';
+import '../../data/models/pomodoro_session_model.dart';
+
+class PomodoroHeatmap extends StatelessWidget {
+  final Map<DateTime, List<PomodoroSessionRecordModel>> data;
+  const PomodoroHeatmap({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    if (data.isEmpty) {
+      return const Center(child: Text('No pomodoro data'));
+    }
+
+    // Convert to dataset with count of work sessions per day
+    final Map<DateTime, int> datasets = {};
+    data.forEach((day, sessions) {
+      datasets[day] = sessions.where((s) => s.isWorkSession).length;
+    });
+
+    final startDate = datasets.keys.reduce((a, b) => a.isBefore(b) ? a : b);
+
+    return HeatMap(
+      startDate: startDate,
+      endDate: DateTime.now(),
+      datasets: datasets,
+      colorMode: ColorMode.color,
+      showColorTip: false,
+      colorsets: const {
+        1: Color(0xFF9be9a8),
+        3: Color(0xFF40c463),
+        5: Color(0xFF30a14e),
+        7: Color(0xFF216e39),
+      },
+    );
+  }
+}

--- a/dntu_focus/pubspec.yaml
+++ b/dntu_focus/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   flutter_staggered_animations: ^1.1.1
   uuid: ^4.5.1
   fl_chart: ^1.0.0
+  flutter_heatmap_calendar: ^1.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `flutter_heatmap_calendar` dependency
- store heatmap data and goal days in `ReportState`
- fetch heatmap data in `ReportCubit`
- display heatmap and goal days using real data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68482173f03c8321b4e0cd107107d829