### PR TITLE
Fix pomodoro session parsing when userId is missing

### DIFF
--- a/dntu_focus/lib/features/report/data/models/pomodoro_session_model.dart
+++ b/dntu_focus/lib/features/report/data/models/pomodoro_session_model.dart
@@ -22,7 +22,7 @@ class TimestampConverter implements JsonConverter<DateTime, Timestamp> {
 @JsonSerializable()
 class PomodoroSessionRecordModel extends Equatable {
   final String id;
-  final String userId;
+  final String? userId;
 
   @TimestampConverter()
   final DateTime startTime;
@@ -37,7 +37,7 @@ class PomodoroSessionRecordModel extends Equatable {
 
   const PomodoroSessionRecordModel({
     required this.id,
-    required this.userId,
+    this.userId,
     required this.startTime,
     required this.endTime,
     required this.duration,

--- a/dntu_focus/lib/features/report/data/models/pomodoro_session_model.g.dart
+++ b/dntu_focus/lib/features/report/data/models/pomodoro_session_model.g.dart
@@ -5,7 +5,7 @@ part of 'pomodoro_session_model.dart';
 PomodoroSessionRecordModel _$PomodoroSessionRecordModelFromJson(Map<String, dynamic> json) {
   return PomodoroSessionRecordModel(
     id: json['id'] as String,
-    userId: json['userId'] as String,
+    userId: json['userId'] as String?,
     startTime: const TimestampConverter().fromJson(json['startTime'] as Timestamp),
     endTime: const TimestampConverter().fromJson(json['endTime'] as Timestamp),
     duration: json['duration'] as int,


### PR DESCRIPTION
## Summary
- allow `userId` in `PomodoroSessionRecordModel` to be nullable

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684823ecf2cc832199ae2b0ebecc5a09