### PR TITLE
Improve Gemini prompt handling

### DIFF
--- a/dntu_focus/lib/core/services/gemini_service.dart
+++ b/dntu_focus/lib/core/services/gemini_service.dart
@@ -5,6 +5,20 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 class GeminiService {
   late final GenerativeModel _model;
 
+  static const String _commandParserSystemPrompt = '''
+Bạn là một bộ phân tích câu lệnh cho ứng dụng quản lý nhiệm vụ. Kết quả phải ở định dạng JSON.
+Các quy tắc:
+- Nếu người dùng muốn tạo task, trả về: {"type":"task","title":"...","duration":<phút>,"break_duration":<phút>,"priority":"High|Medium|Low","due_date":"<ISO 8601>"}
+- Nếu người dùng lên lịch, trả về: {"type":"schedule","title":"...","due_date":"<ISO 8601>","reminder_before":<phút>,"priority":"High|Medium|Low"}
+- Tự suy luận a.m/p.m khi có giờ, mặc định a.m nếu không rõ.
+- Gợi ý priority dựa trên ngữ cảnh (ví dụ: "họp nhóm" -> High).
+Chỉ phản hồi chuỗi JSON duy nhất, không dùng Markdown hay văn bản thừa.
+Ví dụ:
+"làm bài tập toán 25 phút 5 phút nghỉ" -> {"type":"task","title":"Làm bài tập toán","duration":25,"break_duration":5,"priority":"Medium"}
+"ngày mai đi chợ 6 sáng" -> {"type":"schedule","title":"Đi chợ","due_date":"2025-05-04T06:00:00Z","reminder_before":15}
+"họp nhóm lúc 3h" -> {"type":"schedule","title":"Họp nhóm","due_date":"2025-05-03T15:00:00Z","reminder_before":15,"priority":"High"}
+''';
+
   GeminiService() {
     final apiKey = dotenv.env['GEMINI_API_KEY'];
     if (apiKey == null) throw Exception('Gemini API Key không tìm thấy');
@@ -28,18 +42,7 @@ class GeminiService {
 
   // Phân tích câu lệnh người dùng để tạo task hoặc lịch trình
   Future<Map<String, dynamic>> parseUserCommand(String command) async {
-    final prompt = '''
-    Phân tích câu lệnh sau và trả về thông tin dưới dạng JSON:
-    - Nếu là yêu cầu tạo task: trả về title, duration (phút), break_duration (phút), priority (High/Medium/Low), due_date (nếu có, định dạng ISO 8601).
-    - Nếu là yêu cầu lên lịch: trả về title, due_date (định dạng ISO 8601), nhắc nhở trước bao lâu (phút).
-    - Nhận diện a.m/p.m tự động nếu có thời gian (mặc định a.m nếu không rõ).
-    - Gợi ý priority dựa trên ngữ cảnh (ví dụ: "họp nhóm" -> High).
-    Câu lệnh: "$command"
-    Ví dụ: "làm bài tập toán 25 phút 5 phút nghỉ" -> {"type": "task", "title": "Làm bài tập toán", "duration": 25, "break_duration": 5, "priority": "Medium"}
-    Ví dụ: "ngày mai đi chợ 6 sáng" -> {"type": "schedule", "title": "Đi chợ", "due_date": "2025-05-04T06:00:00Z", "reminder_before": 15}
-    Ví dụ: "họp nhóm lúc 3h" -> {"type": "schedule", "title": "Họp nhóm", "due_date": "2025-05-03T15:00:00Z", "reminder_before": 15, "priority": "High"}
-    Trả về chỉ JSON, không thêm ký tự Markdown như ```json hoặc các ký tự thừa.
-    ''';
+    final prompt = '$_commandParserSystemPrompt\nCâu lệnh: "$command"';
 
     String? rawText;
     try {


### PR DESCRIPTION
## Summary
- update `gemini_service` with reusable prompt instructions
- generate user command prompts using system instructions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684abad76fe8832186a06aae73521fe8