### PR TITLE
Prefill task data when editing from AI chat

### DIFF
--- a/dntu_focus/lib/features/tasks/presentation/add_task/add_task_bottom_sheet.dart
+++ b/dntu_focus/lib/features/tasks/presentation/add_task/add_task_bottom_sheet.dart
@@ -10,8 +10,13 @@ import 'project_picker.dart'; // Cần cập nhật file này
 
 class AddTaskBottomSheet extends StatefulWidget {
   final ProjectTagRepository repository; // repository này có thể dùng để ProjectPicker và TagsPicker lấy danh sách project/tag
+  final Map<String, dynamic>? initialTaskData;
 
-  const AddTaskBottomSheet({super.key, required this.repository});
+  const AddTaskBottomSheet({
+    super.key,
+    required this.repository,
+    this.initialTaskData,
+  });
 
   @override
   State<AddTaskBottomSheet> createState() => _AddTaskBottomSheetState();
@@ -26,6 +31,27 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
   List<String> _tagIds = [];
   String? _projectId;
   String? _titleError;
+
+  @override
+  void initState() {
+    super.initState();
+    final data = widget.initialTaskData;
+    if (data != null) {
+      _titleController.text = data['title'] ?? '';
+      if (data['duration'] != null) {
+        final int duration = data['duration'];
+        _estimatedPomodoros = (duration / 25).ceil();
+      }
+      if (data['due_date'] != null) {
+        try {
+          _dueDate = DateTime.parse(data['due_date']);
+        } catch (_) {}
+      }
+      if (data['priority'] != null) {
+        _priority = data['priority'];
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- show AddTaskBottomSheet with parsed task data when user chooses to edit
- allow AddTaskBottomSheet to accept `initialTaskData`
- prefill bottom sheet fields from provided data

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ac15658a88321a173a611613bbd18