### PR TITLE
Fix service crash on stop action

### DIFF
--- a/dntu_focus/android/app/src/main/kotlin/com/example/moji_todo/MainActivity.kt
+++ b/dntu_focus/android/app/src/main/kotlin/com/example/moji_todo/MainActivity.kt
@@ -184,7 +184,11 @@ class MainActivity : FlutterActivity() {
                         }
 
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            startForegroundService(serviceIntent)
+                            if (serviceIntent.action == TimerService.ACTION_STOP) {
+                                startService(serviceIntent)
+                            } else {
+                                startForegroundService(serviceIntent)
+                            }
                         } else {
                             startService(serviceIntent)
                         }
@@ -216,7 +220,11 @@ class MainActivity : FlutterActivity() {
                         }
 
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            startForegroundService(intent)
+                            if (call.method == TimerService.ACTION_STOP) {
+                                startService(intent)
+                            } else {
+                                startForegroundService(intent)
+                            }
                         } else {
                             startService(intent)
                         }
@@ -280,7 +288,11 @@ class MainActivity : FlutterActivity() {
                         }
 
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            startForegroundService(serviceIntent)
+                            if (serviceIntent.action == TimerService.ACTION_STOP) {
+                                startService(serviceIntent)
+                            } else {
+                                startForegroundService(serviceIntent)
+                            }
                         } else {
                             startService(serviceIntent)
                         }
@@ -459,7 +471,11 @@ class MainActivity : FlutterActivity() {
                 }
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                startForegroundService(serviceIntent)
+                if (serviceIntent.action == TimerService.ACTION_STOP) {
+                    startService(serviceIntent)
+                } else {
+                    startForegroundService(serviceIntent)
+                }
             } else {
                 startService(serviceIntent)
             }


### PR DESCRIPTION
## Summary
- prevent TimerService crash by avoiding `startForegroundService` when sending STOP intents

## Testing
- `bash: flutter: command not found`
- `bash: ./gradlew: No such file or directory`

------
https://chatgpt.com/codex/tasks/task_b_684ad14b59908321863d47bb8891888e