### PR TITLE
Handle default due date

### DIFF
--- a/dntu_focus/lib/core/services/gemini_service.dart
+++ b/dntu_focus/lib/core/services/gemini_service.dart
@@ -60,7 +60,16 @@ Ví dụ (giả sử hôm nay là 2025-05-03):
         jsonString = jsonString.substring(0, jsonString.length - 3).trim();
       }
 
-      return jsonDecode(jsonString) as Map<String, dynamic>;
+      final Map<String, dynamic> result =
+          jsonDecode(jsonString) as Map<String, dynamic>;
+
+      // Nếu kết quả không có due_date, gán ngày hiện tại (chỉ ngày, không giờ)
+      if (result['due_date'] == null) {
+        final now = DateTime.now();
+        final today = DateTime(now.year, now.month, now.day);
+        result['due_date'] = today.toIso8601String().split('T').first;
+      }
+      return result;
     } catch (e) {
       print('Error parsing command from Gemini API: $e');
       print('Raw response: $rawText');

--- a/dntu_focus/lib/features/ai_chat/presentation/ai_chat_screen.dart
+++ b/dntu_focus/lib/features/ai_chat/presentation/ai_chat_screen.dart
@@ -194,11 +194,12 @@ class _AIChatScreenState extends State<AIChatScreen> {
     final title = commandResult['title'] ?? '';
     final duration = commandResult['duration'];
     final breakDuration = commandResult['break_duration'];
-    final due = commandResult['due_date'];
+    final due = commandResult['due_date'] ??
+        DateTime.now().toIso8601String().split('T').first;
     final priority = commandResult['priority'];
     final summary =
         "Thêm task \"$title\"? Pomodoro: $duration phút nghỉ $breakDuration phút, "
-        "thời gian: ${due ?? 'không có'}, độ ưu tiên: ${priority ?? 'không'}."
+        "thời gian: $due, độ ưu tiên: ${priority ?? 'không'}."
         "\nGõ \"OK\" để xác nhận hoặc \"Chỉnh sửa\" để thay đổi.";
 
     setState(() {

--- a/dntu_focus/lib/features/tasks/presentation/add_task/add_task_bottom_sheet.dart
+++ b/dntu_focus/lib/features/tasks/presentation/add_task/add_task_bottom_sheet.dart
@@ -212,7 +212,8 @@ class _AddTaskBottomSheetState extends State<AddTaskBottomSheet> {
                       });
                       return;
                     }
-                    final dueDate = _dueDate ?? DateTime.now();
+                    final now = DateTime.now();
+                    final dueDate = _dueDate ?? DateTime(now.year, now.month, now.day);
                     final task = Task(
                       title: _titleController.text,
                       estimatedPomodoros: _estimatedPomodoros,


### PR DESCRIPTION
## Summary
- default `due_date` to today's date when parsing user commands
- show the default date when confirming tasks in the chat UI
- create tasks with start-of-day date when no date selected

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b0f66a1108321bd5f8cbc7807d7fd