### PR TITLE
Fix summary labels

### DIFF
--- a/dntu_focus/lib/features/report/presentation/tab/pomodoro_report_tab_demo.dart
+++ b/dntu_focus/lib/features/report/presentation/tab/pomodoro_report_tab_demo.dart
@@ -247,23 +247,23 @@ class PomodoroReportTabDemo extends StatelessWidget {
     final screenWidth = MediaQuery.of(context).size.width;
     final cardWidth = (screenWidth - 32 - 16) / 2;
 
-    // Thay đổi nhãn ở đây để hiển thị nội dung súc tích hơn
+    // Nhãn dưới mỗi ô thể hiện rõ khoảng thời gian tương ứng
     final cards = [
       SummaryCard(
         value: _formatDuration(state.focusTimeToday),
-        label: 'Hôm nay',
+        label: 'Thời gian tập trung hôm nay',
       ),
       SummaryCard(
         value: _formatDuration(state.focusTimeThisWeek),
-        label: 'Tuần này',
+        label: 'Thời gian tập trung tuần này',
       ),
       SummaryCard(
         value: _formatDuration(state.focusTimeThisTwoWeeks),
-        label: '2 tuần',
+        label: 'Thời gian tập trung 2 tuần',
       ),
       SummaryCard(
         value: _formatDuration(state.focusTimeThisMonth),
-        label: 'Tháng này',
+        label: 'Thời gian tập trung tháng này',
       ),
     ];
 


### PR DESCRIPTION
## Summary
- clarify focus time card labels in the Pomodoro report demo

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b7af548c0832192bd8f420d682720