### PR TITLE
Fix overflow on home view

### DIFF
--- a/dntu_focus/lib/features/home/presentation/home_screen.dart
+++ b/dntu_focus/lib/features/home/presentation/home_screen.dart
@@ -125,11 +125,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             child: Scaffold(
               backgroundColor: Theme.of(context).scaffoldBackgroundColor,
               appBar: const CustomAppBar(),
-              body: Padding(
-                padding: EdgeInsets.symmetric(horizontal: horizontalPadding, vertical: verticalPadding),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.start, // Dồn lên trên
-                  crossAxisAlignment: CrossAxisAlignment.center,
+              body: LayoutBuilder(
+                builder: (context, constraints) {
+                  return SingleChildScrollView(
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(horizontal: horizontalPadding, vertical: verticalPadding),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.start, // Dồn lên trên
+                          crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     // Cụm 1: Select Task with action buttons
                     Row(
@@ -241,9 +246,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceAround,
                         children: const [
-                          Flexible(child: StrictModeMenu()),
-                          Flexible(child: TimerModeMenu()),
-                          Flexible(child: WhiteNoiseMenu()),
+                          Expanded(child: StrictModeMenu()),
+                          Expanded(child: TimerModeMenu()),
+                          Expanded(child: WhiteNoiseMenu()),
                         ],
                       ),
                     ),


### PR DESCRIPTION
## Summary
- ensure home screen scrolls using `SingleChildScrollView`
- give equal width to settings icons with `Expanded`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684bcab65c3c8321858ba7736c87f11e